### PR TITLE
chore: v3 plugins events / scripts docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -97,8 +97,35 @@ Here is how the `composer.json` should look like:
       ]
     }
   },
+  "scripts": {
+  "post-package-install": [
+    "php artisan your:installation-command",
+    "php artisan vendor:publish --tag=your-plugin-config"
+  ],
+  "pre-package-uninstall": [
+    "php artisan your:uninstallation-command"
+  ],
+}
   "minimum-stability": "stable",
   "prefer-stable": true
+}
+```
+
+#### Installation / Uninstallation tasks
+
+You can define installation and uninstallation scripts in your plugin's `composer.json` file, those tasks will be executed when the plugin is installed or uninstalled.
+
+Very useful for setting up and tearing down your plugin's environment, for instance setting up database values, publishing assets, fetching configuration files, etc.
+
+```json
+"scripts": {
+  "post-package-install": [
+    "php artisan your:installation-command",
+    "php artisan vendor:publish --tag=your-plugin-config"
+  ],
+  "pre-package-uninstall": [
+    "php artisan your:uninstallation-command"
+  ],
 }
 ```
 
@@ -417,6 +444,37 @@ The handler must implement the `App\NotificationChannels\NotificationChannel` in
 You can find plenty of examples in
 the [Notification Channels](https://github.com/vitodeploy/vito/tree/3.x/app/NotificationChannels)
 :::
+
+
+### Events
+
+Vito fires events during `Service` installation and uninstallation this way you can tweak/extend the installation process, for example by modifying configuration files or setting up database tables/records.
+
+You can listen to these events in your plugin's service provider:
+
+```php
+use App\Events\ServiceInstalled;
+use App\Events\ServiceUninstalled;
+
+class YourPluginServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Event::listen('service.installed', function (Service $service) {
+            // Do something when the service is installed
+            Log::info("Service installed: {$service->id}");
+        });
+        Event::listen('service.uninstalled', function (Service $service) {
+            // Do something when the service is uninstalled
+            Log::info("Service uninstalled: {$service->id}");
+        });
+    }
+}
+```
+
+### Store Service Data
+
+You can leverage the Service's `type_data` property to store any additional data you need, don't forget to honor other's properties when mutating it.
 
 ## Publishing a Plugin
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -104,7 +104,7 @@ Here is how the `composer.json` should look like:
     ],
     "pre-package-uninstall": [
       "php artisan your:uninstallation-command"
-    ],
+    ]
   },
   "minimum-stability": "stable",
   "prefer-stable": true

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -97,35 +97,8 @@ Here is how the `composer.json` should look like:
       ]
     }
   },
-  "scripts": {
-    "post-package-install": [
-      "php artisan your:installation-command",
-      "php artisan vendor:publish --tag=your-plugin-config"
-    ],
-    "pre-package-uninstall": [
-      "php artisan your:uninstallation-command"
-    ]
-  },
   "minimum-stability": "stable",
   "prefer-stable": true
-}
-```
-
-#### Installation / Uninstallation tasks
-
-You can define installation and uninstallation scripts in your plugin's `composer.json` file, those tasks will be executed when the plugin is installed or uninstalled.
-
-Very useful for setting up and tearing down your plugin's environment, for instance setting up database values, publishing assets, fetching configuration files, etc.
-
-```json
-"scripts": {
-  "post-package-install": [
-    "php artisan your:installation-command",
-    "php artisan vendor:publish --tag=your-plugin-config"
-  ],
-  "pre-package-uninstall": [
-    "php artisan your:uninstallation-command"
-  ],
 }
 ```
 
@@ -444,37 +417,6 @@ The handler must implement the `App\NotificationChannels\NotificationChannel` in
 You can find plenty of examples in
 the [Notification Channels](https://github.com/vitodeploy/vito/tree/3.x/app/NotificationChannels)
 :::
-
-
-### Events
-
-Vito fires events during `Service` installation and uninstallation this way you can tweak/extend the installation process, for example by modifying configuration files or setting up database tables/records.
-
-You can listen to these events in your plugin's service provider:
-
-```php
-use App\Events\ServiceInstalled;
-use App\Events\ServiceUninstalled;
-
-class YourPluginServiceProvider extends ServiceProvider
-{
-    public function boot()
-    {
-        Event::listen('service.installed', function (Service $service) {
-            // Do something when the service is installed
-            Log::info("Service installed: {$service->id}");
-        });
-        Event::listen('service.uninstalled', function (Service $service) {
-            // Do something when the service is uninstalled
-            Log::info("Service uninstalled: {$service->id}");
-        });
-    }
-}
-```
-
-### Store Service Data
-
-You can leverage the Service's `type_data` property to store any additional data you need, don't forget to honor other's properties when mutating it.
 
 ## Publishing a Plugin
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -98,14 +98,14 @@ Here is how the `composer.json` should look like:
     }
   },
   "scripts": {
-  "post-package-install": [
-    "php artisan your:installation-command",
-    "php artisan vendor:publish --tag=your-plugin-config"
-  ],
-  "pre-package-uninstall": [
-    "php artisan your:uninstallation-command"
-  ],
-}
+    "post-package-install": [
+      "php artisan your:installation-command",
+      "php artisan vendor:publish --tag=your-plugin-config"
+    ],
+    "pre-package-uninstall": [
+      "php artisan your:uninstallation-command"
+    ],
+  },
   "minimum-stability": "stable",
   "prefer-stable": true
 }

--- a/versioned_docs/version-3.x/plugins.md
+++ b/versioned_docs/version-3.x/plugins.md
@@ -13,6 +13,7 @@
   - [Register storage providers](#register-storage-providers)
   - [Register source controls](#register-source-controls)
   - [Register notification channels](#register-notification-channels)
+  - [Events](#events)
 - [Publishing a Plugin](#publishing-a-plugin)
 
 ## Introduction
@@ -97,8 +98,35 @@ Here is how the `composer.json` should look like:
       ]
     }
   },
+  "scripts": {
+    "post-package-install": [
+    "php artisan your:installation-command",
+    "php artisan vendor:publish --tag=your-plugin-config"
+  ],
+  "pre-package-uninstall": [
+    "php artisan your:uninstallation-command"
+  ],
+}
   "minimum-stability": "stable",
   "prefer-stable": true
+}
+```
+
+#### Installation / Uninstallation tasks
+
+You can define installation and uninstallation scripts in your plugin's `composer.json` file, those tasks will be executed when the plugin is installed or uninstalled.
+
+Very useful for setting up and tearing down your plugin's environment, for instance setting up database values, publishing assets, fetching configuration files, etc.
+
+```json
+"scripts": {
+  "post-package-install": [
+    "php artisan your:installation-command",
+    "php artisan vendor:publish --tag=your-plugin-config"
+  ],
+  "pre-package-uninstall": [
+    "php artisan your:uninstallation-command"
+  ],
 }
 ```
 
@@ -417,6 +445,37 @@ The handler must implement the `App\NotificationChannels\NotificationChannel` in
 You can find plenty of examples in
 the [Notification Channels](https://github.com/vitodeploy/vito/tree/3.x/app/NotificationChannels)
 :::
+
+
+### Events
+
+Vito fires events during `Service` installation and uninstallation this way you can tweak/extend the installation process, for example by modifying configuration files or setting up database tables/records.
+
+You can listen to these events in your plugin's service provider:
+
+```php
+use App\Events\ServiceInstalled;
+use App\Events\ServiceUninstalled;
+
+class YourPluginServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Event::listen('service.installed', function (Service $service) {
+            // Do something when the service is installed
+            Log::info("Service installed: {$service->id}");
+        });
+        Event::listen('service.uninstalled', function (Service $service) {
+            // Do something when the service is uninstalled
+            Log::info("Service uninstalled: {$service->id}");
+        });
+    }
+}
+```
+
+### Store Service Data
+
+You can leverage the Service's `type_data` property to store any additional data you need, don't forget to honor other's properties when mutating it.
 
 ## Publishing a Plugin
 


### PR DESCRIPTION
This pull request updates the plugin documentation to provide clearer guidance on installation/uninstallation tasks and event handling for plugins. The changes improve both the main `docs/plugins.md` and the versioned documentation in `versioned_docs/version-3.x/plugins.md`, making it easier for plugin authors to automate setup/teardown and react to service lifecycle events.

### Plugin installation and uninstallation automation

* Added documentation for defining `post-package-install` and `pre-package-uninstall` scripts in the plugin's `composer.json`, allowing plugins to automate environment setup and teardown tasks (e.g., running Artisan commands, publishing assets) when installed or uninstalled. [[1]](diffhunk://#diff-416ed26bd34c304ad067cce7817d8cd1eb513c3b096a3761217b2d0297c6ffb1R100-R131) [[2]](diffhunk://#diff-d0df4e159465f377474d4d9d8ce9034e5ed0c45cd2b56cd84a92e61fb80c4c89R101-R132)

### Event handling during service lifecycle

* Introduced a new section explaining how plugins can listen to `service.installed` and `service.uninstalled` events in their service provider, enabling custom logic during service installation/uninstallation (e.g., modifying config files, database setup). [[1]](diffhunk://#diff-416ed26bd34c304ad067cce7817d8cd1eb513c3b096a3761217b2d0297c6ffb1R448-R478) [[2]](diffhunk://#diff-d0df4e159465f377474d4d9d8ce9034e5ed0c45cd2b56cd84a92e61fb80c4c89R449-R479)
* Updated the documentation table of contents to include a reference to the new Events section for easier navigation.

### Service data management

* Added guidance on using the Service's `type_data` property to store additional plugin-specific data, with a reminder to respect existing properties when mutating it. [[1]](diffhunk://#diff-416ed26bd34c304ad067cce7817d8cd1eb513c3b096a3761217b2d0297c6ffb1R448-R478) [[2]](diffhunk://#diff-d0df4e159465f377474d4d9d8ce9034e5ed0c45cd2b56cd84a92e61fb80c4c89R449-R479)